### PR TITLE
fix main script, optimize background-image style

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "material-image",
-  "version": "0.2.0",
+  "version": "0.2.2",
   "description": "Generate random material design background image.",
-  "main": "src/index.js",
+  "main": "dist/materialImage.min.js",
   "keywords": [
     "material",
     "design",

--- a/src/index.js
+++ b/src/index.js
@@ -160,7 +160,7 @@ export default class MaterialImage {
         this.element.style.cssText += `
             background-image: url("${dataUrl}");
             background-repeat: no-repeat;
-            background-size: 100% 100%;`;
+            background-size: cover;`;
         break;
       case 'image':
         const img = document.createElement('img');


### PR DESCRIPTION
`src/index.js`  中 `module.exports = MaterialImage;` 一处在webpack2下会报错，故将入口文件改为编译后的文件，之前背景设置的样式会导致图片变形，改成 `cover` 了，另外，不太建议直接给插入的元素添加style属性，不利于使用者自定义样式